### PR TITLE
Implement skeleton Steam tracker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+venv/
+frontend/node_modules/
+frontend/dist/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,55 @@
-# estordia
+# Estordia
+
+Aplicação para acompanhar inventário da Steam e preços em mercados externos.
+
+## Backend
+
+### Instalação
+
+1. Crie um ambiente virtual:
+   ```bash
+   python3 -m venv venv
+   source venv/bin/activate
+   ```
+2. Instale dependências:
+   ```bash
+   pip install -r requirements.txt
+   ```
+3. Configure a variável `STEAM_API_KEY` com sua chave da Steam Web API e opcionalmente `DATABASE_URL` para usar PostgreSQL.
+4. Execute o servidor:
+   ```bash
+   python -m backend.app
+   ```
+
+## Frontend
+
+A pasta `frontend/` contém uma aplicação React simples.
+
+### Instalação
+
+1. Entre na pasta `frontend` e instale as dependências `npm`:
+   ```bash
+   npm install
+   ```
+2. Inicie o servidor de desenvolvimento:
+   ```bash
+   npm start
+   ```
+
+## Coleta periódica
+
+O script `scripts/update_data.py` deve ser executado periodicamente (ex.: via cron) para atualizar os preços e armazenar no banco.
+
+## Estrutura
+
+```
+backend/
+  app.py          # API Flask
+  models.py       # Modelos SQLAlchemy
+  database.py     # Conexão com banco
+frontend/
+  src/            # Código React
+scripts/
+  update_data.py  # Coletor periódico
+requirements.txt  # Dependências Python
+```

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,0 +1,45 @@
+from flask import Flask, jsonify, request
+from .database import db_session, init_db
+from .models import User, Item, PriceHistory
+import os
+import requests
+
+app = Flask(__name__)
+
+STEAM_API_KEY = os.environ.get('STEAM_API_KEY')
+
+@app.teardown_appcontext
+def shutdown_session(exception=None):
+    db_session.remove()
+
+@app.route('/inventory')
+def get_inventory():
+    steamid = request.args.get('steamid')
+    if not steamid:
+        return jsonify({'error': 'steamid required'}), 400
+    # Example call to Steam Web API
+    if not STEAM_API_KEY:
+        return jsonify({'error': 'STEAM_API_KEY not configured'}), 500
+    url = (
+        f"https://api.steampowered.com/IPlayerService/"
+        f"GetOwnedGames/v1/?key={STEAM_API_KEY}&steamid={steamid}"
+    )
+    try:
+        resp = requests.get(url)
+        data = resp.json()
+    except Exception as e:
+        return jsonify({'error': str(e)}), 500
+    return jsonify(data)
+
+@app.route('/prices')
+def get_prices():
+    item_name = request.args.get('item')
+    if not item_name:
+        return jsonify({'error': 'item required'}), 400
+    # Query database for price history
+    history = PriceHistory.query.filter_by(item_name=item_name).all()
+    return jsonify([h.as_dict() for h in history])
+
+if __name__ == '__main__':
+    init_db()
+    app.run(debug=True)

--- a/backend/database.py
+++ b/backend/database.py
@@ -1,0 +1,12 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import scoped_session, sessionmaker
+from .models import Base
+import os
+
+DATABASE_URL = os.environ.get('DATABASE_URL', 'sqlite:///db.sqlite3')
+
+engine = create_engine(DATABASE_URL, connect_args={'check_same_thread': False})
+db_session = scoped_session(sessionmaker(bind=engine))
+
+def init_db():
+    Base.metadata.create_all(bind=engine)

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,0 +1,33 @@
+from datetime import datetime
+from sqlalchemy import Column, Integer, String, Float, DateTime, ForeignKey
+from sqlalchemy.orm import declarative_base, relationship
+
+Base = declarative_base()
+
+class User(Base):
+    __tablename__ = 'users'
+    id = Column(Integer, primary_key=True)
+    steamid = Column(String, unique=True, nullable=False)
+
+class Item(Base):
+    __tablename__ = 'items'
+    id = Column(Integer, primary_key=True)
+    name = Column(String, nullable=False)
+
+class PriceHistory(Base):
+    __tablename__ = 'price_history'
+    id = Column(Integer, primary_key=True)
+    item_name = Column(String, ForeignKey('items.name'))
+    source = Column(String)  # steam or external
+    price = Column(Float)
+    created_at = Column(DateTime, default=datetime.utcnow)
+
+    item = relationship('Item')
+
+    def as_dict(self):
+        return {
+            'item_name': self.item_name,
+            'source': self.source,
+            'price': self.price,
+            'created_at': self.created_at.isoformat(),
+        }

--- a/frontend/.babelrc
+++ b/frontend/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": ["@babel/preset-env", "@babel/preset-react"]
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "estordia-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "dependencies": {
+    "axios": "^1.6.5",
+    "react": "^18.2.0",
+    "react-chartjs-2": "^5.2.0",
+    "chart.js": "^4.4.0",
+    "react-dom": "^18.2.0"
+  },
+  "scripts": {
+    "start": "webpack serve --mode development",
+    "build": "webpack --mode production"
+  }
+}

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Estordia</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script src="../dist/bundle.js"></script>
+  </body>
+</html>

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,0 +1,58 @@
+import React, { useEffect, useState } from 'react';
+import axios from 'axios';
+import { Line } from 'react-chartjs-2';
+
+function App() {
+  const [inventory, setInventory] = useState([]);
+  const [history, setHistory] = useState([]);
+  const [query, setQuery] = useState('');
+
+  useEffect(() => {
+    // Example: load inventory for a steamid stored in localStorage
+    const steamid = localStorage.getItem('steamid');
+    if (steamid) {
+      axios.get(`/inventory?steamid=${steamid}`).then((res) => {
+        setInventory(res.data);
+      });
+    }
+  }, []);
+
+  const searchItem = () => {
+    axios.get(`/prices?item=${query}`).then((res) => {
+      setHistory(res.data);
+    });
+  };
+
+  const chartData = {
+    labels: history.map((h) => new Date(h.created_at).toLocaleDateString()),
+    datasets: [
+      {
+        label: 'Price',
+        data: history.map((h) => h.price),
+        borderColor: 'rgba(75,192,192,1)',
+        fill: false,
+      },
+    ],
+  };
+
+  return (
+    <div>
+      <h1>Estordia</h1>
+      <div>
+        <input value={query} onChange={(e) => setQuery(e.target.value)} />
+        <button onClick={searchItem}>Search</button>
+      </div>
+      <h2>Inventory</h2>
+      <ul>
+        {inventory.map((item) => (
+          <li key={item.appid}>{item.name}</li>
+        ))}
+      </ul>
+      <div style={{ width: '600px', height: '300px' }}>
+        <Line data={chartData} />
+      </div>
+    </div>
+  );
+}
+
+export default App;

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -1,0 +1,7 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App';
+
+const container = document.getElementById('root');
+const root = createRoot(container);
+root.render(<App />);

--- a/frontend/webpack.config.js
+++ b/frontend/webpack.config.js
@@ -1,0 +1,30 @@
+const path = require('path');
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+
+module.exports = {
+  entry: './src/index.js',
+  output: {
+    path: path.resolve(__dirname, 'dist'),
+    filename: 'bundle.js',
+  },
+  module: {
+    rules: [
+      {
+        test: /\.jsx?$/,
+        exclude: /node_modules/,
+        use: 'babel-loader',
+      },
+    ],
+  },
+  resolve: {
+    extensions: ['.js', '.jsx'],
+  },
+  plugins: [
+    new HtmlWebpackPlugin({ template: './public/index.html' }),
+  ],
+  devServer: {
+    proxy: {
+      '/': 'http://localhost:5000',
+    },
+  },
+};

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+Flask
+SQLAlchemy
+requests

--- a/scripts/update_data.py
+++ b/scripts/update_data.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+"""Periodic data updater."""
+
+from backend.database import db_session, init_db
+from backend.models import Item, PriceHistory
+import requests
+import os
+import time
+
+STEAM_API_KEY = os.environ.get('STEAM_API_KEY')
+
+
+def fetch_prices(item_name):
+    # Placeholder: implement actual fetch from Steam and external sources
+    return {
+        'steam': 0.0,
+        'external': 0.0,
+    }
+
+
+def main():
+    init_db()
+    items = db_session.query(Item).all()
+    for item in items:
+        prices = fetch_prices(item.name)
+        for source, price in prices.items():
+            history = PriceHistory(item_name=item.name, source=source, price=price)
+            db_session.add(history)
+    db_session.commit()
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add Flask backend with inventory and price endpoints
- store data using SQLAlchemy models
- script for periodic data updates
- add basic React frontend with Chart.js graph
- document setup and execution in README

## Testing
- `python -m py_compile backend/app.py backend/models.py backend/database.py scripts/update_data.py`

------
https://chatgpt.com/codex/tasks/task_e_6858cd141ee8832b80c04fbb0dac1dfb