### PR TITLE
Add POST /items endpoint with item storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
 # estordia
+
+This project provides a simple FastAPI backend. To run the development server:
+
+```bash
+uvicorn backend.app:app --reload
+```
+
+## Example request
+
+Create a new item by sending its name:
+
+```bash
+curl -X POST http://localhost:8000/items \
+    -H "Content-Type: application/json" \
+    -d '{"name": "example"}'
+```
+

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,0 +1,36 @@
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+from sqlalchemy import create_engine, Column, Integer, String
+from sqlalchemy.orm import sessionmaker, declarative_base, Session
+
+DATABASE_URL = "sqlite:///./items.db"
+
+engine = create_engine(
+    DATABASE_URL, connect_args={"check_same_thread": False}
+)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+Base = declarative_base()
+
+class Item(Base):
+    __tablename__ = "items"
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, unique=True, index=True)
+
+Base.metadata.create_all(bind=engine)
+
+app = FastAPI()
+
+class ItemCreate(BaseModel):
+    name: str
+
+@app.post("/items", status_code=201)
+def create_item(item: ItemCreate):
+    with SessionLocal() as session:
+        existing: Item | None = session.query(Item).filter(Item.name == item.name).first()
+        if existing:
+            raise HTTPException(status_code=400, detail="Item already exists")
+        new_item = Item(name=item.name)
+        session.add(new_item)
+        session.commit()
+        session.refresh(new_item)
+        return {"id": new_item.id, "name": new_item.name}


### PR DESCRIPTION
## Summary
- build simple FastAPI app with SQLite using SQLAlchemy
- implement POST `/items` endpoint that stores an item if it doesn't already exist
- document running the API and example request in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858d1101050832b96dc994618c66fba